### PR TITLE
Example of try-catch logic in a cloud hook,.

### DIFF
--- a/samples/trycatch/README.md
+++ b/samples/trycatch/README.md
@@ -1,0 +1,10 @@
+# Try-Catch
+
+This cloudhook provides an example of how to simulate a try-catch block in bash.  This will allow you to send notifications for cloudhook failures only if you so wish.  
+
+That way you protect against notification fatigue!
+
+### Example Scenario
+
+1. A failure occurs in a cloudhook
+2. An action is taken in response.  What action?  You decide!

--- a/samples/trycatch/trycatch.sh
+++ b/samples/trycatch/trycatch.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+#
+# Cloud Hook: post-code-deploy
+#
+# The post-code-deploy hook is run whenever you use the Workflow page to
+# deploy new code to an environment, either via drag-drop or by selecting
+# an existing branch or tag from the Code drop-down list. See
+# ../README.md for details.
+#
+# Usage: post-code-deploy site target-env source-branch deployed-tag repo-url
+#                         repo-type
+
+site="$1"
+target_env="$2"
+source_branch="$3"
+deployed_tag="$4"
+repo_url="$5"
+repo_type="$6"
+
+(
+  set -ev
+  ls
+  # example of a failure:
+  # cd blah
+  ls
+  set +v
+)
+
+retVal=$(($? + 0))
+if [ $retVal -eq 0 ]; then
+    echo "Cloudhook Completed Successfully"
+else
+    if [ "$source_branch" != "$deployed_tag" ]; then
+        ERROR_MESSAGE="Acquia code deploy failed: **$site.$target_env** using branch **$source_branch** as **$deployed_tag**!"
+
+    else
+        ERROR_MESSAGE="Acquia code deploy failed: **$site.$target_env** using tag **$deployed_tag**!"
+    fi
+
+    echo "$ERROR_MESSAGE"
+fi


### PR DESCRIPTION
This can help people detect failures in their cloudhooks and take an action in response.  The goal here is to help protect against notification fatigue!