### PR TITLE
NW-16019: Add new hook directories and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,35 +165,36 @@ Example: When you use the Workflow page to drag files from Prod to Dev, the file
 
 The pre-site-wipe hook is run before a site's database and files are wiped from an environment. This allows you to perform backups or other preparatory actions before the site data is removed.
 
-Usage: pre-site-wipe site target-env
+Usage: pre-site-wipe app-name stage
 
-* site: The site name. This is the same as the Acquia Cloud username for the site.
-* target-env: The environment from which the site will be wiped.
+* app-name: The application name for the site.
+* stage: The environment stage (dev, test, or prod) from which the site will be wiped.
 
 ### post-site-wipe
 
 The post-site-wipe hook is run after a site's database and files have been wiped from an environment. This allows you to perform cleanup, notifications, or initialization of a fresh environment.
 
-Usage: post-site-wipe site target-env
+Usage: post-site-wipe app-name stage
 
-* site: The site name. This is the same as the Acquia Cloud username for the site.
-* target-env: The environment from which the site was wiped.
+* app-name: The application name for the site.
+* stage: The environment stage (dev, test, or prod) from which the site was wiped.
 
 ### post-site-instance-duplicate
 
 The post-site-instance-duplicate hook is run after a site instance has been duplicated to create a new environment. This allows you to perform post-duplication configuration, data scrubbing, or environment-specific setup.
 
-Usage: post-site-instance-duplicate site target-env source-env
+Usage: post-site-instance-duplicate app-name stage source-site-name
 
-* site: The site name. This is the same as the Acquia Cloud username for the site.
-* target-env: The environment that was created from the duplication.
-* source-env: The environment from which the site was duplicated.
+* app-name: The application name for the target site.
+* stage: The environment stage (dev, test, or prod) of the target environment.
+* source-site-name: The name of the source site that was duplicated.
 
 ### post-site-associate
 
 The post-site-associate hook is run after a site has been associated with an environment. This allows you to perform initialization tasks, configure environment-specific settings, or set up integrations.
 
-Usage: post-site-associate site target-env
+Usage: post-site-associate app-name stage site-name
 
-* site: The site name. This is the same as the Acquia Cloud username for the site.
-* target-env: The environment with which the site was associated.
+* app-name: The application name for the site.
+* stage: The environment stage (dev, test, or prod) with which the site was associated.
+* site-name: The name of the site that was associated.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Sample scripts currently include:
 * post-code-update.tmpl: Template for post-code-update hook scripts.
 * post-db-copy.tmpl: Template for post-db-copy hook scripts.
 * post-files-copy.tmpl: Template for post-files-copy hook scripts.
+* pre-site-wipe.tmpl: Template for pre-site-wipe hook scripts.
+* post-site-wipe.tmpl: Template for post-site-wipe hook scripts.
+* post-site-instance-duplicate.tmpl: Template for post-site-instance-duplicate hook scripts.
+* post-site-associate.tmpl: Template for post-site-associate hook scripts.
 * update-db.sh: Run drush updatedb to perform database updates.
 * db-scrub.sh: Scrub important information from a Drupal database.
 * drupal-tests.sh: Run Drupal simpletests.
@@ -156,3 +160,40 @@ Usage: post-files-copy site target-env source-env
 Example: When you use the Workflow page to drag files from Prod to Dev, the files-copy hook will be run like:
 
     post-files-copy mysite prod dev
+
+### pre-site-wipe
+
+The pre-site-wipe hook is run before a site's database and files are wiped from an environment. This allows you to perform backups or other preparatory actions before the site data is removed.
+
+Usage: pre-site-wipe site target-env
+
+* site: The site name. This is the same as the Acquia Cloud username for the site.
+* target-env: The environment from which the site will be wiped.
+
+### post-site-wipe
+
+The post-site-wipe hook is run after a site's database and files have been wiped from an environment. This allows you to perform cleanup, notifications, or initialization of a fresh environment.
+
+Usage: post-site-wipe site target-env
+
+* site: The site name. This is the same as the Acquia Cloud username for the site.
+* target-env: The environment from which the site was wiped.
+
+### post-site-instance-duplicate
+
+The post-site-instance-duplicate hook is run after a site instance has been duplicated to create a new environment. This allows you to perform post-duplication configuration, data scrubbing, or environment-specific setup.
+
+Usage: post-site-instance-duplicate site target-env source-env
+
+* site: The site name. This is the same as the Acquia Cloud username for the site.
+* target-env: The environment that was created from the duplication.
+* source-env: The environment from which the site was duplicated.
+
+### post-site-associate
+
+The post-site-associate hook is run after a site has been associated with an environment. This allows you to perform initialization tasks, configure environment-specific settings, or set up integrations.
+
+Usage: post-site-associate site target-env
+
+* site: The site name. This is the same as the Acquia Cloud username for the site.
+* target-env: The environment with which the site was associated.

--- a/samples/post-site-associate.tmpl
+++ b/samples/post-site-associate.tmpl
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# Cloud Hook: post-site-associate
+#
+# The post-site-associate hook is run after a site has been associated with
+# an environment. This allows you to perform initialization tasks, configure
+# environment-specific settings, or set up integrations.
+#
+# Usage: post-site-associate site target-env
+
+site="$1"
+target_env="$2"
+
+echo "$site.$target_env: Site associated with environment."

--- a/samples/post-site-associate.tmpl
+++ b/samples/post-site-associate.tmpl
@@ -6,9 +6,10 @@
 # an environment. This allows you to perform initialization tasks, configure
 # environment-specific settings, or set up integrations.
 #
-# Usage: post-site-associate site target-env
+# Usage: post-site-associate app-name stage site-name
 
-site="$1"
-target_env="$2"
+app_name="$1"
+stage="$2"
+site_name="$3"
 
-echo "$site.$target_env: Site associated with environment."
+echo "$app_name.$stage: Site $site_name associated with environment."

--- a/samples/post-site-instance-duplicate.tmpl
+++ b/samples/post-site-instance-duplicate.tmpl
@@ -1,0 +1,15 @@
+#!/bin/sh
+#
+# Cloud Hook: post-site-instance-duplicate
+#
+# The post-site-instance-duplicate hook is run after a site instance has been
+# duplicated to create a new environment. This allows you to perform
+# post-duplication configuration, data scrubbing, or environment-specific setup.
+#
+# Usage: post-site-instance-duplicate site target-env source-env
+
+site="$1"
+target_env="$2"
+source_env="$3"
+
+echo "$site.$target_env: Site instance duplicated from $source_env."

--- a/samples/post-site-instance-duplicate.tmpl
+++ b/samples/post-site-instance-duplicate.tmpl
@@ -6,10 +6,10 @@
 # duplicated to create a new environment. This allows you to perform
 # post-duplication configuration, data scrubbing, or environment-specific setup.
 #
-# Usage: post-site-instance-duplicate site target-env source-env
+# Usage: post-site-instance-duplicate app-name stage source-site-name
 
-site="$1"
-target_env="$2"
-source_env="$3"
+app_name="$1"
+stage="$2"
+source_site_name="$3"
 
-echo "$site.$target_env: Site instance duplicated from $source_env."
+echo "$app_name.$stage: Site instance duplicated from $source_site_name."

--- a/samples/post-site-wipe.tmpl
+++ b/samples/post-site-wipe.tmpl
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# Cloud Hook: post-site-wipe
+#
+# The post-site-wipe hook is run after a site's database and files have been
+# wiped from an environment. This allows you to perform cleanup, notifications,
+# or initialization of a fresh environment.
+#
+# Usage: post-site-wipe site target-env
+
+site="$1"
+target_env="$2"
+
+echo "$site.$target_env: Site wipe completed."

--- a/samples/post-site-wipe.tmpl
+++ b/samples/post-site-wipe.tmpl
@@ -6,9 +6,9 @@
 # wiped from an environment. This allows you to perform cleanup, notifications,
 # or initialization of a fresh environment.
 #
-# Usage: post-site-wipe site target-env
+# Usage: post-site-wipe app-name stage
 
-site="$1"
-target_env="$2"
+app_name="$1"
+stage="$2"
 
-echo "$site.$target_env: Site wipe completed."
+echo "$app_name.$stage: Site wipe completed."

--- a/samples/pre-site-wipe.tmpl
+++ b/samples/pre-site-wipe.tmpl
@@ -6,9 +6,9 @@
 # from an environment. This allows you to perform backups or other preparatory
 # actions before the site data is removed.
 #
-# Usage: pre-site-wipe site target-env
+# Usage: pre-site-wipe app-name stage
 
-site="$1"
-target_env="$2"
+app_name="$1"
+stage="$2"
 
-echo "$site.$target_env: Preparing for site wipe."
+echo "$app_name.$stage: Preparing for site wipe."

--- a/samples/pre-site-wipe.tmpl
+++ b/samples/pre-site-wipe.tmpl
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# Cloud Hook: pre-site-wipe
+#
+# The pre-site-wipe hook is run before a site's database and files are wiped
+# from an environment. This allows you to perform backups or other preparatory
+# actions before the site data is removed.
+#
+# Usage: pre-site-wipe site target-env
+
+site="$1"
+target_env="$2"
+
+echo "$site.$target_env: Preparing for site wipe."


### PR DESCRIPTION
## Summary

- Added support for four new Acquia Cloud hooks with directories for all environments (common/dev/test/prod):
  - `pre-site-wipe`: Hook that runs before a site is wiped
  - `post-site-wipe`: Hook that runs after a site is wiped
  - `post-site-instance-duplicate`: Hook that runs after a site instance is duplicated
  - `post-site-associate`: Hook that runs after a site is associated with an environment
- Created sample template scripts for each hook in the `samples/` directory
- Updated `README.md` with documentation for all new hooks

## Test plan

- [ ] Verify all hook directories exist in common, dev, test, and prod
- [ ] Verify sample template files are executable and follow the existing pattern
- [ ] Verify README documentation is accurate and follows existing format

🤖 Generated with [Claude Code](https://claude.com/claude-code)