### PR TITLE
NW-16229 | Fix site-code-deploy hooks parameter order

### DIFF
--- a/samples/post-site-code-deploy.tmpl
+++ b/samples/post-site-code-deploy.tmpl
@@ -7,16 +7,21 @@
 # that allows you to perform post-deployment tasks, such as disabling
 # maintenance mode or running database updates. See ../README.md for details.
 #
-# Usage: post-site-code-deploy site target-env source-branch deployed-tag repo-url
-#                              repo-type site-name extra-args
+# Usage: post-site-code-deploy site target-env site-name [extra-args...]
+#
+# Arguments:
+#   $1: site (application name)
+#   $2: target-env (environment/stage name)
+#   $3: site-name (the specific site being deployed)
+#   $4+: extra-args (source-branch, deployed-tag, repo-url, repo-type, etc.)
 
 site="$1"
 target_env="$2"
-source_branch="$3"
-deployed_tag="$4"
-repo_url="$5"
-repo_type="$6"
-site_name="$7"
-extra_args="$8"
+site_name="$3"
+# Extra args start at position 4
+source_branch="$4"
+deployed_tag="$5"
+repo_url="$6"
+repo_type="$7"
 
 echo "$site.$target_env: Completed deployment of $deployed_tag to site $site_name."

--- a/samples/pre-site-code-deploy.tmpl
+++ b/samples/pre-site-code-deploy.tmpl
@@ -7,16 +7,21 @@
 # you to prepare a site for deployment, such as enabling maintenance mode.
 # See ../README.md for details.
 #
-# Usage: pre-site-code-deploy site target-env source-branch deployed-tag repo-url
-#                             repo-type site-name extra-args
+# Usage: pre-site-code-deploy site target-env site-name [extra-args...]
+#
+# Arguments:
+#   $1: site (application name)
+#   $2: target-env (environment/stage name)
+#   $3: site-name (the specific site being deployed)
+#   $4+: extra-args (source-branch, deployed-tag, repo-url, repo-type, etc.)
 
 site="$1"
 target_env="$2"
-source_branch="$3"
-deployed_tag="$4"
-repo_url="$5"
-repo_type="$6"
-site_name="$7"
-extra_args="$8"
+site_name="$3"
+# Extra args start at position 4
+source_branch="$4"
+deployed_tag="$5"
+repo_url="$6"
+repo_type="$7"
 
 echo "$site.$target_env: Preparing to deploy $deployed_tag to site $site_name."


### PR DESCRIPTION
## Summary
Updates the sample templates for `pre-site-code-deploy` and `post-site-code-deploy` hooks to use the correct parameter order.

## Problem
The current templates show the OLD parameter order where `site_name` was passed as the last extra argument at position 7:
```bash
$1=site, $2=target-env, $3=source-branch, ..., $7=site-name, $8=extra-args
```

## Solution
Update to the NEW standard order where `site_name` is a dedicated parameter at position 3:
```bash
$1=site, $2=target-env, $3=site-name, $4+=extra-args
```

## Changes
- Updated `samples/pre-site-code-deploy.tmpl`
- Updated `samples/post-site-code-deploy.tmpl`
- Improved documentation with clear argument descriptions
- Added comments explaining the parameter positions

## Benefits
- **More intuitive**: Site-specific hooks receive the site name early in the parameter list
- **First-class parameter**: `site_name` is not buried in extra args
- **Consistent**: Aligns with other site-level hooks like `post-site-associate`
- **Easier parsing**: Hook authors can easily access site name without parsing extra args

## Background
This change aligns the sample templates with the implementation in fn-task-operator where site-level hooks receive site_name as a dedicated third parameter. This standardization was implemented in fn-task-operator PR #2977 (NW-16229).

## Migration Note
Existing hook scripts following the old template will need to be updated to parse `site_name` from position 3 instead of position 7.

Related:
- fn-task-operator PR #2977
- fn-example-repos commit 273fcd7ca
- fn-e2e PR #522